### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkStripTsImageFilter.h
+++ b/include/itkStripTsImageFilter.h
@@ -95,6 +95,7 @@ class ITK_EXPORT
 StripTsImageFilter : public ImageToImageFilter<TImageType, TAtlasLabelType>
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(StripTsImageFilter);
 
   // standard class type alias
   using Self = StripTsImageFilter;
@@ -144,10 +145,6 @@ protected:
 
 
 private:
-
-  StripTsImageFilter(const Self&); //purposely not implemented
-  void operator=(const Self&); //purposely not implemented
-
   ImagePointer            m_PatientImage;
   AtlasImagePointer       m_AtlasImage;
   AtlasLabelPointer       m_AtlasLabels;


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.